### PR TITLE
docs: add .env.example for SmartBike Mobile

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# API server (local or staging)
+VITE_API_URL=http://localhost:4000
+
+# MQTT broker for testing without bike hardware
+MQTT_BROKER=broker.hivemq.com
+MQTT_PORT=1883
+MQTT_TOPIC=smartbike/dev/demo


### PR DESCRIPTION
Added a `.env.example` file containing placeholders for API URL and MQTT broker.
This provides a standard template for developers to configure local environments and test data streams without requiring hardware.
