### PR TITLE
add links to Redback docs and UI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,8 @@ Alternatively the Link tag can also be used
 This will navigate to the home screen and clear the stack.
 
 
+- [SmartBike Mobile Documentation](https://redback-operations.github.io/redback-documentation/docs/category/mobile-app-documentation)  
+- [Getting Started Guide](https://redback-operations.github.io/redback-documentation/docs/web-mobile-app-dev/frontend/getting-started)  
+- [Redback UI Components](https://www.npmjs.com/package/@redbackops/redback-ui)
+
+


### PR DESCRIPTION
Updated README with direct links to SmartBike Mobile documentation, Getting Started guide, and Redback UI components.
This improves onboarding by helping new contributors quickly find official resources.
